### PR TITLE
Adds i18n detection

### DIFF
--- a/feature.js
+++ b/feature.js
@@ -1080,6 +1080,17 @@ features["HTML.Microdata.Document.DocumentFragment.getItems"] = !!(document.crea
     features["DOM.Intl.exists"] = !!(window.Intl);
 }());
 
+(function(){
+    var works = false;
+    var number = 0;
+    try {
+	number.toLocaleString("i");
+    } catch (e) {
+	works = (e.name === "RangeError");
+    }
+    features["DOM.Number.toLocalString(locale, options)"] = works;
+}());
+
 }());(function () {
    var features = window.features,
        load = {},

--- a/feature.js
+++ b/feature.js
@@ -1076,6 +1076,9 @@ features["HTML.Microdata.Document.getItems"] = !!(document.getItems);
 features["HTML.Microdata.Document.DocumentFragment.getItems"] = !!(document.createDocumentFragment().getItems);
 }());
 
+(function(){
+    features["DOM.Intl.exists"] = !!(window.Intl);
+}());
 
 }());(function () {
    var features = window.features,


### PR DESCRIPTION
Some browsers don't support the locale and options arguments for toLocaleNumber and this is a simple way to format currency... It seems that Intl.NumberFormat is the basis for toLocaleNumber, but it's probably to have two sets of detection...
